### PR TITLE
Improve Codex desktop assistant UI

### DIFF
--- a/openai_helper.py
+++ b/openai_helper.py
@@ -12,8 +12,30 @@ DEFAULT_MODEL = "gpt-3.5-turbo"
 MAX_TOKENS = 300
 
 BASE_DIR = Path(__file__).resolve().parent
-USAGE_FILE = BASE_DIR / "usage.json"
-HISTORY_FILE = BASE_DIR / "history.json"
+PROJECT_DIR = BASE_DIR
+USAGE_FILE = PROJECT_DIR / "usage.json"
+HISTORY_FILE = PROJECT_DIR / "history.json"
+
+
+def set_project_dir(path: str) -> None:
+    """Set file paths for usage and history under a project directory."""
+    global PROJECT_DIR, USAGE_FILE, HISTORY_FILE, usage_data
+    PROJECT_DIR = Path(path)
+    PROJECT_DIR.mkdir(parents=True, exist_ok=True)
+    USAGE_FILE = PROJECT_DIR / "usage.json"
+    HISTORY_FILE = PROJECT_DIR / "history.json"
+    usage_data = _load_json(
+        USAGE_FILE,
+        {
+            "session_tokens": 0,
+            "session_cost": 0.0,
+            "total_tokens": 0,
+            "total_cost": 0.0,
+        },
+    )
+    usage_data["session_tokens"] = 0
+    usage_data["session_cost"] = 0.0
+    _save_usage()
 
 
 def _load_json(path, default):
@@ -33,6 +55,7 @@ usage_data = _load_json(USAGE_FILE, {
 
 
 def _save_usage() -> None:
+    PROJECT_DIR.mkdir(parents=True, exist_ok=True)
     try:
         with open(USAGE_FILE, "w", encoding="utf-8") as f:
             json.dump(usage_data, f, indent=2)
@@ -46,6 +69,7 @@ _save_usage()
 
 
 def _record_history(entry: dict) -> None:
+    PROJECT_DIR.mkdir(parents=True, exist_ok=True)
     data = _load_json(HISTORY_FILE, [])
     data.append(entry)
     try:
@@ -112,4 +136,11 @@ def estimate_cost(usage, model):
         # Based on typical 2025 pricing
         return (input_tokens / 1000 * 0.01) + (output_tokens / 1000 * 0.03)
     return 0.0
+
+__all__ = [
+    "send_prompt",
+    "get_usage",
+    "estimate_cost",
+    "set_project_dir",
+]
 


### PR DESCRIPTION
## Summary
- add project-aware usage/history paths
- embed checkboxes in Settings tab within the main notebook UI
- replace old panes with a four-tab layout
- add project management helpers and buttons
- support automatic project reload and theme switching

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6888c375f6f48329842bdb44eccfdd94