### PR TITLE
Improve UI layout and generated files

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file. The format 
 ## [Unreleased]
 - Initial creation of CHANGELOG
 - Modernized UI with emoji buttons, label frames, and theme selector
+- Combined prompt and response view with sticky status bar
+- Added top-bar settings menu and numbered generated files support
 
 ## [0.1.0] - 2025-07-29
 ### Added


### PR DESCRIPTION
## Summary
- refactor layout: prompt and response stacked vertically
- add settings dropdown menu with theme support
- parse generated file names and number outputs
- update changelog

## Testing
- `python -m py_compile main.py openai_helper.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_688a7cbd3cf883299a1273bd390996e3