### PR TITLE
Compact UI and prompt safeguards

### DIFF
--- a/openai_helper.py
+++ b/openai_helper.py
@@ -85,6 +85,8 @@ def get_usage() -> dict:
 
 def send_prompt(prompt_text: str, model: str = DEFAULT_MODEL, task: str = ""):
     """Send a prompt to OpenAI and record history and usage."""
+    if len(prompt_text) > 10_000:
+        return "[ERROR] Prompt too long. Try disabling project context.", None
     try:
         response = client.chat.completions.create(
             model=model,


### PR DESCRIPTION
## Summary
- refactor main window to a paned layout with side tabs
- limit response area height and keep footer pinned
- show estimated prompt tokens
- trim long context in `build_prompt` and stop if too large
- protect OpenAI API from overly long prompts

## Testing
- `python -m py_compile main.py openai_helper.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_688ac54c7d28832996462b8e9b232a76