### PR TITLE
feat: add streaming responses and context tiers

### DIFF
--- a/console_widget.py
+++ b/console_widget.py
@@ -54,12 +54,15 @@ class ActivityConsole(tk.Frame):
 
         tk.Button(tb, text="Pause", command=self._toggle_pause).pack(side="right")
         tk.Button(tb, text="Copy", command=self._copy).pack(side="right")
-        tk.Button(tb, text="Clear", command=self._clear).pack(side="right")
+        tk.Button(tb, text="Clear Log", command=self._clear).pack(side="right")
         tk.Button(tb, text="Save…", command=self._save).pack(side="right")
         tk.Button(tb, text="Log File…", command=self._choose_file).pack(side="right")
 
         self.text = tk.Text(self, wrap="word", height=12, state="disabled")
-        self.text.pack(fill="both", expand=True)
+        scroll = tk.Scrollbar(self, orient="vertical", command=self.text.yview)
+        self.text.configure(yscrollcommand=scroll.set)
+        self.text.pack(side="left", fill="both", expand=True)
+        scroll.pack(side="right", fill="y")
         self.text.tag_config("INFO", foreground="black")
         self.text.tag_config("WARN", foreground="orange")
         self.text.tag_config("ERROR", foreground="red")

--- a/context.py
+++ b/context.py
@@ -6,6 +6,9 @@ class AppContext:
             'show_prompt_cost': True,
             'auto_load_last_project': True,
             'include_history': False,
+            'use_turn_summaries': True,
+            'context_tier': 'Standard',
+            'detailed_files': [],
             'theme': 'darkly',
             'last_project': '',
             'verbose': True,
@@ -16,8 +19,10 @@ class AppContext:
         self.total_tokens = 0
         self.active_project = ''
         self.context_summary = {}
+        self.project_overview = ''
         self.generated_files = []
         self.history_path = 'data/history.json'
+        self.turn_summaries_path = 'data/turn_summaries.json'
         self.settings_path = 'data/settings.json'
         self.summaries_path = 'data/summaries.json'
         self.project_file = 'data/active_project.codexproj'

--- a/logic/project_manager.py
+++ b/logic/project_manager.py
@@ -23,6 +23,8 @@ def new_project(ctx, name: str) -> Path:
     ctx.active_project = str(folder)
     ctx.settings['last_project'] = str(folder)
     set_project_dir(str(folder))
+    ctx.history_path = str(folder / 'history.json')
+    ctx.turn_summaries_path = str(folder / 'turn_summaries.json')
     return folder
 
 
@@ -31,6 +33,8 @@ def load_project(ctx, file_path: str) -> None:
     ctx.active_project = str(folder)
     ctx.settings['last_project'] = str(folder)
     set_project_dir(str(folder))
+    ctx.history_path = str(folder / 'history.json')
+    ctx.turn_summaries_path = str(folder / 'turn_summaries.json')
     try:
         with open(file_path, 'r', encoding='utf-8') as f:
             meta = json.load(f)

--- a/logic/prompt_builder.py
+++ b/logic/prompt_builder.py
@@ -1,5 +1,6 @@
 import json
 from typing import Tuple
+import os
 
 from utils import approx_tokens
 from context import AppContext
@@ -12,23 +13,53 @@ def build_prompt(ctx: AppContext, user_prompt: str) -> Tuple[str, bool]:
     token_total = 0
     char_total = 0
     trimmed = False
+    tier = ctx.settings.get('context_tier', 'Standard')
     if ctx.settings.get('use_project_context') and ctx.context_summary:
-        for rel, summary in ctx.context_summary.items():
-            entry = f"{rel}: {summary}"
-            tokens = approx_tokens(entry)
-            if token_total + tokens > 3000 or char_total + len(entry) > 10_000:
-                trimmed = True
-                break
-            token_total += tokens
-            char_total += len(entry)
+        if tier == 'Basic':
+            overview = getattr(ctx, 'project_overview', '')
+            if not overview:
+                overview = ' '.join(ctx.context_summary.values())
+            entry = f"Project Overview: {overview}"
             parts.append(entry)
-        if parts:
-            parts = ['context'] + parts
-        if trimmed:
-            parts.append('Context trimmed to fit within limits.')
-            emit('WARN', 'BUILD', 'Context truncated', max_tokens=3000, tokens=token_total)
-        emit('INFO', 'BUILD', 'Collected project context', files=len(ctx.context_summary), tokens=token_total)
-    if ctx.settings.get('include_history'):
+            token_total += approx_tokens(entry)
+        else:
+            for rel, summary in ctx.context_summary.items():
+                entry = f"{rel}: {summary}"
+                tokens = approx_tokens(entry)
+                if token_total + tokens > 3000 or char_total + len(entry) > 10_000:
+                    trimmed = True
+                    break
+                token_total += tokens
+                char_total += len(entry)
+                parts.append(entry)
+            if tier == 'Detailed':
+                for rel in ctx.settings.get('detailed_files', []):
+                    path = os.path.join(getattr(ctx, 'project_root', ''), rel)
+                    try:
+                        with open(path, 'r', encoding='utf-8', errors='ignore') as f:
+                            code = f.read()
+                    except Exception:
+                        continue
+                    tokens = approx_tokens(code)
+                    if token_total + tokens > 3000 or char_total + len(code) > 10_000:
+                        trimmed = True
+                        break
+                    token_total += tokens
+                    char_total += len(code)
+                    parts.append(f"{rel} code:\n{code}")
+            if trimmed:
+                parts.append('Context trimmed to fit within limits.')
+                emit('WARN', 'BUILD', 'Context truncated', max_tokens=3000, tokens=token_total)
+            emit('INFO', 'BUILD', 'Collected project context', files=len(ctx.context_summary), tokens=token_total)
+    if ctx.settings.get('use_turn_summaries'):
+        try:
+            with open(ctx.turn_summaries_path, 'r', encoding='utf-8') as f:
+                summaries = json.load(f)
+        except Exception:
+            summaries = []
+        for s in summaries[-5:]:
+            parts.append(f"Summary: {s}")
+    elif ctx.settings.get('include_history'):
         try:
             with open(ctx.history_path, 'r', encoding='utf-8') as f:
                 hist = json.load(f)
@@ -38,7 +69,13 @@ def build_prompt(ctx: AppContext, user_prompt: str) -> Tuple[str, bool]:
             text = f"User: {item['prompt']}\nAssistant: {item['response']}"
             parts.append(text)
     parts.append(user_prompt)
-    return '\n\n'.join(parts), trimmed
+    final = '\n\n'.join(parts)
+    tokens = approx_tokens(final)
+    if tokens > 4000 or len(final) > 10_000:
+        final = final[:10_000] + "\n\n(Context trimmed to fit)"
+        trimmed = True
+        emit('WARN', 'BUILD', 'Prompt trimmed', tokens=tokens)
+    return final, trimmed
 
 
 __all__ = ['build_prompt']

--- a/logic/turn_summary.py
+++ b/logic/turn_summary.py
@@ -1,0 +1,16 @@
+from services.openai_helper import send_prompt, save_turn_summary
+
+
+def summarize_turn(prompt: str, response: str) -> str:
+    """Create a 1–2 sentence summary for a prompt/response pair."""
+    combo = (
+        "Summarize the following user/assistant exchange in 1-2 sentences.\n"
+        f"User: {prompt}\nAssistant: {response}"
+    )
+    summary, _ = send_prompt(combo)
+    summary = summary.strip()
+    save_turn_summary(summary)
+    return summary
+
+
+__all__ = ["summarize_turn"]

--- a/services/openai_helper.py
+++ b/services/openai_helper.py
@@ -16,15 +16,17 @@ BASE_DIR = Path(__file__).resolve().parent
 PROJECT_DIR = BASE_DIR
 USAGE_FILE = PROJECT_DIR / "usage.json"
 HISTORY_FILE = PROJECT_DIR / "history.json"
+TURN_SUMMARIES_FILE = PROJECT_DIR / "turn_summaries.json"
 
 
 def set_project_dir(path: str) -> None:
-    """Set file paths for usage and history under a project directory."""
-    global PROJECT_DIR, USAGE_FILE, HISTORY_FILE, usage_data
+    """Set file paths for usage, history and summaries under a project directory."""
+    global PROJECT_DIR, USAGE_FILE, HISTORY_FILE, TURN_SUMMARIES_FILE, usage_data
     PROJECT_DIR = Path(path)
     PROJECT_DIR.mkdir(parents=True, exist_ok=True)
     USAGE_FILE = PROJECT_DIR / "usage.json"
     HISTORY_FILE = PROJECT_DIR / "history.json"
+    TURN_SUMMARIES_FILE = PROJECT_DIR / "turn_summaries.json"
     usage_data = _load_json(
         USAGE_FILE,
         {
@@ -80,9 +82,84 @@ def _record_history(entry: dict) -> None:
         pass
 
 
+def save_turn_summary(text: str) -> None:
+    """Append a turn summary string to the project file."""
+    data = _load_json(TURN_SUMMARIES_FILE, [])
+    data.append(text)
+    try:
+        with open(TURN_SUMMARIES_FILE, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except Exception:
+        pass
+
+
 def get_usage() -> dict:
     """Return current usage stats."""
     return usage_data
+
+
+def stream_chat(
+    prompt_text: str,
+    model: str,
+    task: str,
+    on_chunk,
+    on_done,
+    on_error,
+    should_cancel,
+):
+    """Stream a chat completion and emit progress events."""
+    emit("INFO", "STREAM", "Queued request", model=model, task=task)
+    if len(prompt_text) > 10_000:
+        on_error("Prompt too long. Try disabling project context.")
+        return
+    try:
+        stream = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": "You are a helpful coding assistant."},
+                {"role": "user", "content": prompt_text},
+            ],
+            temperature=0.7,
+            max_tokens=500,
+            stream=True,
+        )
+        emit("INFO", "STREAM", "Sending request")
+        full_text = ""
+        usage = None
+        for part in stream:
+            if should_cancel():
+                emit("WARN", "STREAM", "Stream cancelled")
+                break
+            delta = part.choices[0].delta
+            if delta and delta.content:
+                full_text += delta.content
+                on_chunk(delta.content)
+                emit("INFO", "STREAM", "Chunk", size=len(delta.content))
+            if getattr(part.choices[0], "finish_reason", None) is not None:
+                usage = getattr(part, "usage", None)
+        if usage:
+            cost = estimate_cost(usage, model)
+            usage_data["session_tokens"] += usage.total_tokens
+            usage_data["session_cost"] += cost
+            usage_data["total_tokens"] += usage.total_tokens
+            usage_data["total_cost"] += cost
+            _save_usage()
+            _record_history(
+                {
+                    "ts": time.time(),
+                    "model": model,
+                    "task": task,
+                    "prompt": prompt_text,
+                    "response": full_text,
+                    "tokens": usage.total_tokens,
+                    "cost": cost,
+                }
+            )
+        emit("INFO", "STREAM", "Done")
+        on_done(full_text, usage)
+    except Exception as e:
+        emit("ERROR", "STREAM", "HTTP error", error=str(e))
+        on_error(str(e))
 
 def send_prompt(prompt_text: str, model: str = DEFAULT_MODEL, task: str = ""):
     """Send a prompt to OpenAI and record history and usage."""
@@ -158,5 +235,7 @@ __all__ = [
     "get_usage",
     "estimate_cost",
     "set_project_dir",
+    "stream_chat",
+    "save_turn_summary",
 ]
 

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -42,6 +42,7 @@ def launch_ui(ctx):
     folder_btn = ttk.Button(project_frame, text='🗂️ Load Folder')
     for b in (new_btn, load_btn, save_btn, folder_btn):
         b.pack(side='left', padx=2)
+    progress = ttk.Progressbar(project_frame, mode='indeterminate', length=120)
     settings_btn = create_settings_panel(ctx, project_frame, style)
     settings_btn.pack(side='right')
 
@@ -71,7 +72,7 @@ def launch_ui(ctx):
         console.show()
     emit('INFO', 'SYSTEM', 'Activity console started')
 
-    events = UIEvents(ctx, resp_widgets, lambda files: files_update(files), status_bar, refresh_history)
+    events = UIEvents(ctx, resp_widgets, lambda files: files_update(files), status_bar, refresh_history, app, folder_btn, progress)
     new_btn.config(command=events.new_project)
     load_btn.config(command=events.load_project)
     save_btn.config(command=events.save_project_as)

--- a/ui/settings_panel.py
+++ b/ui/settings_panel.py
@@ -1,5 +1,7 @@
 import tkinter as tk
+from tkinter import filedialog
 from ttkbootstrap import Style
+import os
 
 
 def create_settings_panel(ctx, root, style: Style):
@@ -9,15 +11,34 @@ def create_settings_panel(ctx, root, style: Style):
     use_ctx = tk.BooleanVar(value=ctx.settings.get('use_project_context', True))
     include_hist = tk.BooleanVar(value=ctx.settings.get('include_history', False))
     show_cost = tk.BooleanVar(value=ctx.settings.get('show_prompt_cost', True))
+    use_turn_summaries = tk.BooleanVar(value=ctx.settings.get('use_turn_summaries', True))
+    context_tier = tk.StringVar(value=ctx.settings.get('context_tier', 'Standard'))
 
     def _apply_settings():
         ctx.settings['use_project_context'] = use_ctx.get()
         ctx.settings['include_history'] = include_hist.get()
         ctx.settings['show_prompt_cost'] = show_cost.get()
+        ctx.settings['use_turn_summaries'] = use_turn_summaries.get()
+        ctx.settings['context_tier'] = context_tier.get()
 
     settings_menu.add_checkbutton(label='Use project context', variable=use_ctx, command=_apply_settings)
     settings_menu.add_checkbutton(label='Include chat history', variable=include_hist, command=_apply_settings)
+    settings_menu.add_checkbutton(label='Use turn summaries', variable=use_turn_summaries, command=_apply_settings)
     settings_menu.add_checkbutton(label='Show prompt cost', variable=show_cost, command=_apply_settings)
+
+    tier_menu = tk.Menu(settings_menu, tearoff=False)
+    for tier in ['Basic', 'Standard', 'Detailed']:
+        tier_menu.add_radiobutton(label=tier, value=tier, variable=context_tier, command=_apply_settings)
+    settings_menu.add_cascade(label='Context tier', menu=tier_menu)
+
+    def _select_detailed():
+        initial = getattr(ctx, 'project_root', '') or '.'
+        files = filedialog.askopenfilenames(initialdir=initial)
+        if files:
+            root = getattr(ctx, 'project_root', '')
+            ctx.settings['detailed_files'] = [os.path.relpath(f, root) if root and f.startswith(root) else f for f in files]
+            ctx.save_settings()
+    settings_menu.add_command(label='Select detailed files', command=_select_detailed)
 
     theme_choice = tk.StringVar(value=ctx.settings.get('theme', 'darkly'))
     theme_menu = tk.Menu(settings_menu, tearoff=False)

--- a/ui/tabs/history_tab.py
+++ b/ui/tabs/history_tab.py
@@ -6,7 +6,10 @@ from tkinter import ttk
 def create_tab(ctx, parent):
     frame = ttk.Frame(parent, padding=10)
     history_text = tk.Text(frame, wrap='word', state='disabled')
+    scroll = ttk.Scrollbar(frame, orient='vertical', command=history_text.yview)
+    history_text.configure(yscrollcommand=scroll.set)
     history_text.pack(side='left', fill='both', expand=True)
+    scroll.pack(side='right', fill='y')
 
     def refresh():
         try:

--- a/ui/tabs/response_tab.py
+++ b/ui/tabs/response_tab.py
@@ -33,10 +33,22 @@ def create_tab(ctx, parent):
 
     response_frame = ttk.LabelFrame(frame, text='Response', padding=10)
     response_frame.pack(fill='both', expand=True, pady=(10, 0))
-    response_text = tk.Text(response_frame, wrap='word', height=10)
+    text_container = ttk.Frame(response_frame)
+    text_container.pack(fill='both', expand=True)
+    response_text = tk.Text(text_container, wrap='word', height=10)
+    scroll = ttk.Scrollbar(text_container, orient='vertical', command=response_text.yview)
+    response_text.configure(yscrollcommand=scroll.set)
     response_text.pack(side='left', fill='both', expand=True)
-    copy_btn = ttk.Button(response_frame, text='📋 Copy', command=lambda: frame.clipboard_append(response_text.get('1.0', tk.END)))
-    copy_btn.pack(pady=5, anchor='e')
+    scroll.pack(side='right', fill='y')
+    btn_bar = ttk.Frame(response_frame)
+    btn_bar.pack(fill='x', pady=5)
+    copy_btn = ttk.Button(btn_bar, text='Copy', command=lambda: frame.clipboard_append(response_text.get('1.0', tk.END)))
+    copy_btn.pack(side='left', padx=2)
+    clear_btn = ttk.Button(btn_bar, text='Clear', command=lambda: response_text.delete('1.0', tk.END))
+    clear_btn.pack(side='left', padx=2)
+    cancel_btn = ttk.Button(btn_bar, text='Cancel')
+    cancel_btn.pack(side='left', padx=2)
+    cancel_btn.pack_forget()
 
     return {
         'frame': frame,
@@ -46,6 +58,7 @@ def create_tab(ctx, parent):
         'token_var': token_var,
         'model_var': model_var,
         'task_var': task_var,
+        'cancel_btn': cancel_btn,
     }
 
 


### PR DESCRIPTION
## Summary
- stream assistant replies with cancel support and verbose logging
- add project scan progress UI and token-efficient turn summaries
- introduce tiered context settings and response controls

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68994cf9b4a883299ee2348b5d409cc5