### PR TITLE
Add budgeted context engine with hybrid retrieval

### DIFF
--- a/context_engine/README.md
+++ b/context_engine/README.md
@@ -1,0 +1,29 @@
+# Codex Assist Context Engine
+
+This package implements a lightweight, four layer memory system for the demo `codex-assist` app.
+
+## Layers
+- **Active Context (AC)** – rolling window of the last conversational turns.
+- **Decision Ledger (DL)** – structured YAML of decisions, constraints, todos, prefs and ids.
+- **Facts Store (FS)** – extractive / abstractive snippets with embeddings for retrieval.
+- **Cold Archive (CA)** – raw transcript history kept in SQLite.
+
+## Quick start
+```bash
+python -m context_engine.cli ingest --user "We chose Astro; add loader" --assistant "Done; TODO confetti"
+python -m context_engine.cli compose --next "Improve loader feedback"
+python -m context_engine.cli stats
+```
+
+## Embedders
+The engine accepts any object implementing `Embedder`. `HashEmbedder` is the default. An `OpenAIEmbedder`
+adapter is provided; set `OPENAI_API_KEY` in the environment to use it.
+
+## Token budgeting
+Token counts use `tiktoken` when available and fall back to a simple word split. Functions `len_tokens` and
+`cap_to_tokens` help enforce budgets.
+
+## Design rationale
+- **Structured > prose** – DL is kept as YAML for deterministic merging.
+- **Two‑track summaries** – both extractive and abstractive snippets are stored for richer retrieval.
+- **Temporal decay** – AC trims to the most recent pairs; DL trims oldest entries when over budget.

--- a/context_engine/__init__.py
+++ b/context_engine/__init__.py
@@ -1,0 +1,3 @@
+"""Context Engine package."""
+from .engine import ContextEngine
+__all__ = ["ContextEngine"]

--- a/context_engine/cli.py
+++ b/context_engine/cli.py
@@ -1,0 +1,33 @@
+"""Minimal CLI demo for context engine."""
+from __future__ import annotations
+import argparse
+from .engine import ContextEngine
+
+
+def main():
+    parser = argparse.ArgumentParser(prog="context-engine")
+    sub = parser.add_subparsers(dest="cmd")
+
+    ing = sub.add_parser("ingest")
+    ing.add_argument("--user", required=True)
+    ing.add_argument("--assistant", required=True)
+
+    comp = sub.add_parser("compose")
+    comp.add_argument("--next", required=True)
+
+    sub.add_parser("stats")
+
+    args = parser.parse_args()
+    engine = ContextEngine()
+    if args.cmd == "ingest":
+        engine.update_memory(args.user, args.assistant)
+    elif args.cmd == "compose":
+        ctx = engine.compose_context(args.next)
+        print(ctx)
+    elif args.cmd == "stats":
+        print(engine.stats())
+    else:
+        parser.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/context_engine/embeddings.py
+++ b/context_engine/embeddings.py
@@ -1,0 +1,46 @@
+"""Embedding interfaces."""
+from __future__ import annotations
+from typing import List
+import numpy as np
+import hashlib
+import os
+
+class Embedder:
+    def encode(self, texts: List[str]) -> np.ndarray:  # pragma: no cover - interface
+        raise NotImplementedError
+
+class HashEmbedder(Embedder):
+    """Deterministic hash-based embeddings for tests."""
+    def __init__(self, dim: int = 64):
+        self.dim = dim
+
+    def encode(self, texts: List[str]) -> np.ndarray:
+        vecs = []
+        for t in texts:
+            h = hashlib.sha256(t.encode("utf-8")).digest()
+            # repeat to fill dim
+            arr = np.frombuffer(h, dtype=np.uint8).astype(float)
+            if len(arr) < self.dim:
+                arr = np.tile(arr, int(np.ceil(self.dim / len(arr))))
+            vecs.append(arr[: self.dim])
+        mat = np.vstack(vecs)
+        # normalize
+        norms = np.linalg.norm(mat, axis=1, keepdims=True) + 1e-9
+        return mat / norms
+
+class OpenAIEmbedder(Embedder):
+    """Adapter for OpenAI embeddings API (not used in tests)."""
+    def __init__(self, model: str = "text-embedding-3-large"):
+        self.model = model
+        self.api_key = os.getenv("OPENAI_API_KEY")
+        if not self.api_key:
+            raise RuntimeError("OPENAI_API_KEY not set")
+
+    def encode(self, texts: List[str]) -> np.ndarray:  # pragma: no cover - network
+        import requests, json
+        headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+        data = {"input": texts, "model": self.model}
+        resp = requests.post("https://api.openai.com/v1/embeddings", headers=headers, json=data)
+        resp.raise_for_status()
+        emb = [d["embedding"] for d in resp.json()["data"]]
+        return np.array(emb, dtype=float)

--- a/context_engine/engine.py
+++ b/context_engine/engine.py
@@ -1,0 +1,111 @@
+"""High level Context Engine implementation."""
+from __future__ import annotations
+import uuid
+from .store import Store
+from .embeddings import HashEmbedder, Embedder
+from .models import Turn, DecisionLedger, FSChunk
+from . import extractors
+from . import reducers
+from . import retrieval
+from .tokens import len_tokens, cap_to_tokens
+import yaml
+
+class ContextEngine:
+    def __init__(self, db_path: str = "context.db", index_dir: str = "indexes", embedder: Embedder = None,
+                 ac_pairs:int=2, dl_cap_tokens:int=250, es_tokens:int=120, budget_tokens:int=900):
+        self.store = Store(db_path)
+        self.embedder = embedder or HashEmbedder()
+        self.ac_pairs = ac_pairs
+        self.dl_cap_tokens = dl_cap_tokens
+        self.es_tokens = es_tokens
+        self.budget_tokens = budget_tokens
+
+    # -------- Update phase ---------
+    def update_memory(self, user_msg: str, assistant_msg: str) -> None:
+        # append raw turns
+        user_turn = Turn(role="user", text=user_msg)
+        assistant_turn = Turn(role="assistant", text=assistant_msg)
+        self.store.append_turn(user_turn)
+        turn_id = self.store.append_turn(assistant_turn)
+        # update AC
+        ac = self.store.load_ac()
+        ac.extend([user_turn, assistant_turn])
+        ac = ac[-self.ac_pairs*2:]
+        self.store.save_ac(ac)
+        # decision ledger
+        dl = self.store.load_ledger()
+        delta_user = extractors.extract_dl_signals(user_msg)
+        delta_assistant = extractors.extract_dl_signals(assistant_msg)
+        for field in ["decisions","constraints","todos","prefs"]:
+            setattr(dl, field, getattr(dl, field) + getattr(delta_user, field) + getattr(delta_assistant, field))
+        dl.ids.update(delta_user.ids)
+        dl.ids.update(delta_assistant.ids)
+        # cap DL tokens by trimming lists
+        def dl_tokens(d: DecisionLedger) -> int:
+            return len_tokens(yaml.dump(d.model_dump()))
+        while dl_tokens(dl) > self.dl_cap_tokens:
+            trimmed = False
+            for field in ["decisions","constraints","todos","prefs"]:
+                lst = getattr(dl, field)
+                if lst:
+                    lst.pop(0)
+                    trimmed = True
+                    if dl_tokens(dl) <= self.dl_cap_tokens:
+                        break
+            if not trimmed:
+                break
+        self.store.save_ledger(dl)
+        # summaries
+        ext = extractors.make_extractive(user_msg, assistant_msg, self.es_tokens)
+        abs_s = extractors.make_abstractive(user_msg, assistant_msg, self.es_tokens)
+        vecs = self.embedder.encode([ext, abs_s])
+        fs_chunks = self.store.load_fs_chunks()
+        for text, typ, vec in zip([ext, abs_s], ["extractive","abstractive"], vecs):
+            new_chunk = FSChunk(id=str(uuid.uuid4()), type=typ, tags=[], text=text, src_turn=turn_id, vec=vec)
+            duplicate = None
+            for ch in fs_chunks:
+                if ch.vec is None:
+                    continue
+                sim = float(ch.vec @ vec)
+                if sim > 0.9:
+                    duplicate = ch
+                    break
+            if duplicate:
+                merged = reducers.densify(duplicate.text, text, self.es_tokens)
+                duplicate.text = merged
+                duplicate.vec = (duplicate.vec + vec) / 2
+                self.store.upsert_fs_chunk(duplicate)
+            else:
+                self.store.upsert_fs_chunk(new_chunk)
+                fs_chunks.append(new_chunk)
+
+    # -------- Compose phase ---------
+    def compose_context(self, next_user_msg: str) -> str:
+        ac = self.store.load_ac()
+        ac_text_lines = [f"{t.role}: {t.text}" for t in ac]
+        ac_text = "\n".join(ac_text_lines)
+        ac_text = cap_to_tokens(ac_text, 400)
+        dl = self.store.load_ledger()
+        dl_yaml = yaml.dump(dl.model_dump())
+        dl_yaml = cap_to_tokens(dl_yaml, self.dl_cap_tokens)
+        base = ac_text + "\n" + dl_yaml
+        used = len_tokens(base)
+        remaining = max(0, self.budget_tokens - used)
+        fs_chunks = self.store.load_fs_chunks()
+        retrieved = retrieval.hybrid_search(next_user_msg, dl, fs_chunks, self.embedder, k=5)
+        snippets = [c.text for c in retrieved]
+        cond = reducers.condenser(snippets, remaining)
+        context = base + "\n" + cond
+        if len_tokens(context) > self.budget_tokens:
+            context = reducers.final_budget_cut(context, self.budget_tokens)
+        return context
+
+    def stats(self) -> dict:
+        ac = self.store.load_ac()
+        dl = self.store.load_ledger()
+        fs_count = self.store.count_fs()
+        return {
+            "ac_pairs": len(ac)//2,
+            "dl_tokens": len_tokens(yaml.dump(dl.model_dump())),
+            "fs_chunks": fs_count,
+        }

--- a/context_engine/extractors.py
+++ b/context_engine/extractors.py
@@ -1,0 +1,51 @@
+"""Heuristic extractors for DL signals and summaries."""
+from __future__ import annotations
+import re
+from typing import List
+from .models import DecisionLedger
+from .tokens import cap_to_tokens
+
+_signal_re = re.compile(r"^(decide|constraint|todo|pref|id):\s*(.*)", re.I)
+
+def extract_dl_signals(text: str) -> DecisionLedger:
+    dl = DecisionLedger()
+    for line in text.splitlines():
+        m = _signal_re.match(line.strip())
+        if not m:
+            continue
+        key, val = m.group(1).lower(), m.group(2).strip()
+        if key == "decide":
+            dl.decisions.append(val)
+        elif key == "constraint":
+            dl.constraints.append(val)
+        elif key == "todo":
+            dl.todos.append(val)
+        elif key == "pref":
+            dl.prefs.append(val)
+        elif key == "id":
+            parts = val.split("=", 1)
+            if len(parts) == 2:
+                dl.ids[parts[0].strip()] = parts[1].strip()
+    return dl
+
+# Optional stub for LLM extraction
+def llm_extract_signals(text: str) -> DecisionLedger:  # pragma: no cover - placeholder
+    return extract_dl_signals(text)
+
+def make_extractive(u: str, a: str, max_tokens: int = 120) -> str:
+    lines: List[str] = []
+    for part in [u, a]:
+        for sent in re.split(r"[\n\.]+", part):
+            sent = sent.strip()
+            if not sent:
+                continue
+            lines.append(f"- {sent}")
+    text = "\n".join(lines)
+    return cap_to_tokens(text, max_tokens)
+
+def make_abstractive(u: str, a: str, max_tokens: int = 120) -> str:
+    combined = u.strip() + " " + a.strip()
+    sentences = re.split(r"[\n\.]+", combined)
+    sentences = [s.strip() for s in sentences if s.strip()]
+    summary = ". ".join(sentences[:4])
+    return cap_to_tokens(summary, max_tokens)

--- a/context_engine/models.py
+++ b/context_engine/models.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+from typing import List, Literal, Optional, Dict
+from datetime import datetime
+import numpy as np
+from pydantic import BaseModel, Field, ConfigDict
+
+class Turn(BaseModel):
+    role: Literal["user", "assistant"]
+    text: str
+    ts: datetime = Field(default_factory=datetime.utcnow)
+
+class DecisionLedger(BaseModel):
+    decisions: List[str] = Field(default_factory=list)
+    constraints: List[str] = Field(default_factory=list)
+    todos: List[str] = Field(default_factory=list)
+    prefs: List[str] = Field(default_factory=list)
+    ids: Dict[str, str] = Field(default_factory=dict)
+
+class FSChunk(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    id: str
+    type: Literal["extractive", "abstractive"]
+    tags: List[str] = Field(default_factory=list)
+    text: str
+    src_turn: int
+    vec: Optional[np.ndarray] = None
+
+class Memory(BaseModel):
+    AC: List[Turn] = Field(default_factory=list)
+    DL: DecisionLedger = Field(default_factory=DecisionLedger)
+    CA_ptr: int = 0

--- a/context_engine/reducers.py
+++ b/context_engine/reducers.py
@@ -1,0 +1,24 @@
+"""Reducers and condensers."""
+from __future__ import annotations
+from typing import List
+from .tokens import len_tokens, cap_to_tokens
+
+
+def _split_lines(text: str) -> List[str]:
+    return [l.strip() for l in text.splitlines() if l.strip()]
+
+def densify(existing: str, incoming: str, max_tokens: int = 160) -> str:
+    merged = list(dict.fromkeys(_split_lines(existing) + _split_lines(incoming)))
+    text = "\n".join(merged)
+    return cap_to_tokens(text, max_tokens)
+
+def condenser(chunks: List[str], target_tokens: int) -> str:
+    text = "\n".join(chunks)
+    if len_tokens(text) <= target_tokens:
+        return text
+    return cap_to_tokens(text, target_tokens)
+
+def final_budget_cut(context: str, target_tokens: int) -> str:
+    if len_tokens(context) <= target_tokens:
+        return context
+    return cap_to_tokens(context, target_tokens)

--- a/context_engine/retrieval.py
+++ b/context_engine/retrieval.py
@@ -1,0 +1,53 @@
+"""Hybrid retrieval and MMR."""
+from __future__ import annotations
+from typing import List
+import numpy as np
+from rank_bm25 import BM25Okapi
+from .models import DecisionLedger, FSChunk
+
+
+def _tokenize(text: str) -> List[str]:
+    return text.lower().split()
+
+def hybrid_search(query: str, dl: DecisionLedger, fs_chunks: List[FSChunk], embedder, k: int = 8, mmr_lambda: float = 0.7) -> List[FSChunk]:
+    if not fs_chunks:
+        return []
+    # build corpus
+    corpus = [f"{c.text} {' '.join(c.tags)}" for c in fs_chunks]
+    tokenized_corpus = [_tokenize(c) for c in corpus]
+    bm25 = BM25Okapi(tokenized_corpus)
+    q_extra = " ".join(list(dl.ids.values()) + dl.decisions + dl.todos + dl.constraints)
+    full_query = f"{query} {q_extra}".strip()
+    bm25_scores = bm25.get_scores(_tokenize(full_query))
+    # embeddings
+    texts = [c.text for c in fs_chunks]
+    chunk_vecs = np.vstack([c.vec for c in fs_chunks]) if fs_chunks[0].vec is not None else embedder.encode(texts)
+    for c, v in zip(fs_chunks, chunk_vecs):
+        c.vec = v
+    q_vec = embedder.encode([full_query])[0]
+    cos_scores = chunk_vecs @ q_vec
+    # ranks
+    bm25_rank = np.argsort(np.argsort(-bm25_scores))
+    cos_rank = np.argsort(np.argsort(-cos_scores))
+    rrf = 1/(60 + bm25_rank) + 1/(60 + cos_rank)
+    order = np.argsort(-rrf)
+    # apply MMR
+    selected = []
+    selected_vecs = []
+    for idx in order:
+        candidate = fs_chunks[idx]
+        cand_vec = chunk_vecs[idx]
+        if not selected:
+            selected.append(candidate)
+            selected_vecs.append(cand_vec)
+        else:
+            sims = [cand_vec @ v for v in selected_vecs]
+            max_sim = max(sims)
+            mmr_score = mmr_lambda * (cand_vec @ q_vec) - (1 - mmr_lambda) * max_sim
+            if mmr_score <= 0:
+                continue
+            selected.append(candidate)
+            selected_vecs.append(cand_vec)
+        if len(selected) >= k:
+            break
+    return selected

--- a/context_engine/store.py
+++ b/context_engine/store.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+import sqlite3
+import json
+import numpy as np
+from typing import List
+from .models import Turn, FSChunk, DecisionLedger
+import yaml
+
+class Store:
+    def __init__(self, db_path: str = "context.db"):
+        self.conn = sqlite3.connect(db_path)
+        self.conn.execute("PRAGMA journal_mode=WAL")
+        self._init_db()
+
+    def _init_db(self) -> None:
+        c = self.conn.cursor()
+        c.execute("""CREATE TABLE IF NOT EXISTS transcripts(
+                    turn_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    role TEXT, text TEXT, ts TEXT)""")
+        c.execute("""CREATE TABLE IF NOT EXISTS fs_chunks(
+                    id TEXT PRIMARY KEY,
+                    type TEXT, tags TEXT, text TEXT, src_turn INTEGER, vec BLOB)""")
+        c.execute("""CREATE TABLE IF NOT EXISTS ledger(
+                    id INTEGER PRIMARY KEY, yaml TEXT)""")
+        c.execute("""CREATE TABLE IF NOT EXISTS meta(
+                    key TEXT PRIMARY KEY, value TEXT)""")
+        # ensure ledger row
+        c.execute("INSERT OR IGNORE INTO ledger(id, yaml) VALUES(1, ?)" , (yaml.dump(DecisionLedger().model_dump()),))
+        c.execute("INSERT OR IGNORE INTO meta(key, value) VALUES('ac', '[]')")
+        self.conn.commit()
+
+    # transcripts
+    def append_turn(self, turn: Turn) -> int:
+        c = self.conn.cursor()
+        c.execute("INSERT INTO transcripts(role,text,ts) VALUES(?,?,?)", (turn.role, turn.text, turn.ts.isoformat()))
+        self.conn.commit()
+        return c.lastrowid
+
+    def last_turns(self, n: int) -> List[Turn]:
+        c = self.conn.cursor()
+        rows = c.execute("SELECT role,text,ts FROM transcripts ORDER BY turn_id DESC LIMIT ?", (n,)).fetchall()
+        rows.reverse()
+        return [Turn(role=r[0], text=r[1], ts=r[2]) for r in rows]
+
+    # ledger
+    def load_ledger(self) -> DecisionLedger:
+        c = self.conn.cursor()
+        (yaml_txt,) = c.execute("SELECT yaml FROM ledger WHERE id=1").fetchone()
+        data = yaml.safe_load(yaml_txt) or {}
+        return DecisionLedger(**data)
+
+    def save_ledger(self, dl: DecisionLedger) -> None:
+        c = self.conn.cursor()
+        c.execute("UPDATE ledger SET yaml=? WHERE id=1", (yaml.dump(dl.model_dump()),))
+        self.conn.commit()
+
+    # meta AC
+    def load_ac(self) -> List[Turn]:
+        c = self.conn.cursor()
+        (txt,) = c.execute("SELECT value FROM meta WHERE key='ac'").fetchone()
+        data = json.loads(txt)
+        return [Turn(**t) for t in data]
+
+    def save_ac(self, turns: List[Turn]) -> None:
+        c = self.conn.cursor()
+        serial = json.dumps([t.model_dump(mode="json") for t in turns])
+        c.execute("INSERT OR REPLACE INTO meta(key,value) VALUES('ac', ?)" , (serial,))
+        self.conn.commit()
+
+    # FS chunks
+    def upsert_fs_chunk(self, chunk: FSChunk) -> None:
+        vec_blob = None
+        if chunk.vec is not None:
+            vec_blob = chunk.vec.astype(np.float32).tobytes()
+        tags_txt = ",".join(chunk.tags)
+        c = self.conn.cursor()
+        c.execute("REPLACE INTO fs_chunks(id,type,tags,text,src_turn,vec) VALUES(?,?,?,?,?,?)",
+                  (chunk.id, chunk.type, tags_txt, chunk.text, chunk.src_turn, vec_blob))
+        self.conn.commit()
+
+    def load_fs_chunks(self) -> List[FSChunk]:
+        c = self.conn.cursor()
+        rows = c.execute("SELECT id,type,tags,text,src_turn,vec FROM fs_chunks").fetchall()
+        chunks = []
+        for r in rows:
+            vec = None
+            if r[5] is not None:
+                arr = np.frombuffer(r[5], dtype=np.float32)
+                vec = arr
+            tags = r[2].split(',') if r[2] else []
+            chunks.append(FSChunk(id=r[0], type=r[1], tags=tags, text=r[3], src_turn=r[4], vec=vec))
+        return chunks
+
+    def count_fs(self) -> int:
+        c = self.conn.cursor()
+        (n,) = c.execute("SELECT COUNT(*) FROM fs_chunks").fetchone()
+        return n

--- a/context_engine/tokens.py
+++ b/context_engine/tokens.py
@@ -1,0 +1,26 @@
+"""Token utilities using tiktoken when available."""
+from __future__ import annotations
+from typing import List
+
+try:
+    import tiktoken
+except Exception:  # pragma: no cover - fallback
+    tiktoken = None
+
+def _simple_tokenize(text: str) -> List[str]:
+    return text.split()
+
+def len_tokens(text: str, model_hint: str = "gpt-4o-mini") -> int:
+    if tiktoken is not None:
+        try:
+            enc = tiktoken.encoding_for_model(model_hint)
+            return len(enc.encode(text))
+        except Exception:
+            pass
+    return len(_simple_tokenize(text))
+
+def cap_to_tokens(text: str, target: int, model_hint: str = "gpt-4o-mini") -> str:
+    tokens = _simple_tokenize(text)
+    if len(tokens) <= target:
+        return text
+    return " ".join(tokens[:target])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "codex-assist-context-engine"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "faiss-cpu==1.7.4",
+    "rank-bm25==0.2.2",
+    "pyyaml==6.0.1",
+    "tiktoken==0.5.1",
+    "numpy==1.26.4",
+    "scikit-learn==1.3.2",
+    "pydantic==1.10.13",
+]
+
+[tool.pytest.ini_options]
+addopts = "-q"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,21 @@
+from context_engine.engine import ContextEngine
+from context_engine.embeddings import HashEmbedder
+from context_engine.tokens import len_tokens
+
+
+def test_engine_update_and_compose(tmp_path):
+    db = tmp_path / "ctx.db"
+    eng = ContextEngine(db_path=str(db), embedder=HashEmbedder(), dl_cap_tokens=50, budget_tokens=200, es_tokens=40)
+    eng.update_memory("decide: use Astro\nWe chose Astro; add loader", "Done; todo: add confetti")
+    eng.update_memory("decide: use Astro\nWe chose Astro; add loader", "Done; todo: add confetti")
+    stats = eng.stats()
+    assert stats["dl_tokens"] <= 50
+    # AC window size
+    ac = eng.store.load_ac()
+    assert len(ac) == 4
+    # FS dedupe -> only two chunks
+    fs_chunks = eng.store.load_fs_chunks()
+    assert len(fs_chunks) == 2
+    # compose context under budget
+    ctx = eng.compose_context("Improve loader feedback")
+    assert len_tokens(ctx) <= 200

--- a/tests/test_reducers.py
+++ b/tests/test_reducers.py
@@ -1,0 +1,13 @@
+import context_engine.reducers as R
+import context_engine.tokens as T
+
+def test_densify_and_condenser():
+    existing = "- a\n- b"
+    incoming = "- b\n- c"
+    merged = R.densify(existing, incoming, max_tokens=20)
+    assert "a" in merged and "b" in merged and "c" in merged
+    chunks = ["word" * 10, "second chunk"]
+    condensed = R.condenser(chunks, target_tokens=5)
+    assert T.len_tokens(condensed) <= 5
+    final = R.final_budget_cut(condensed + " more words", target_tokens=5)
+    assert T.len_tokens(final) <= 5

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,0 +1,21 @@
+from context_engine.embeddings import HashEmbedder
+from context_engine.models import FSChunk, DecisionLedger
+from context_engine import retrieval
+
+
+def make_chunk(id, text):
+    emb = HashEmbedder().encode([text])[0]
+    return FSChunk(id=id, type="extractive", tags=[], text=text, src_turn=0, vec=emb)
+
+def test_hybrid_search_mmr():
+    chunks = [
+        make_chunk("1", "Use Astro for the new site"),
+        make_chunk("2", "Add loader with progress bar"),
+        make_chunk("3", "Fix authentication bug"),
+    ]
+    dl = DecisionLedger()
+    embed = HashEmbedder()
+    res = retrieval.hybrid_search("Astro loader", dl, chunks, embedder=embed, k=2)
+    assert len(res) == 2
+    ids = {c.id for c in res}
+    assert ids <= {"1", "2", "3"}


### PR DESCRIPTION
## Summary
- implement four-layer memory system with Active Context, Decision Ledger, Facts Store and Cold Archive
- add hybrid BM25 + embedding retrieval with MMR, reducers and token helpers
- expose CLI demo, hash-based embedder and unit tests

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a3693df988329ac5896dc3b006e26