### PR TITLE
Replace PySimpleGUI entry with Tkinter UI

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,24 +1,14 @@
-"""Entry point wiring the PySimpleGUI application."""
-import PySimpleGUI as sg
+"""Application entry point launching the Tkinter UI."""
 
-from state import AppState
-from ui import create_main_window
-from events import handle_event, update_status
-from tokens import recalc_and_update
+from context import AppContext
+from ui.layout import launch_ui
 
 
 def main() -> None:
-    state = AppState()
-    window = create_main_window(state)
-    update_status(window, state)
-    recalc_and_update(window, state)
-    while True:
-        event, values = window.read()
-        if event in (sg.WIN_CLOSED, 'Exit'):
-            break
-        handle_event(window, state, event, values)
-    window.close()
+    """Start the desktop assistant."""
+    ctx = AppContext()
+    launch_ui(ctx)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 openai
 python-dotenv
 ttkbootstrap
-PySimpleGUI


### PR DESCRIPTION
## Summary
- launch Tkinter-based interface instead of PySimpleGUI
- drop unused PySimpleGUI dependency

## Testing
- `pytest` *(fails: No module named 'context_engine')*


------
https://chatgpt.com/codex/tasks/task_e_689a8eaaf9388329b82525e16299d3f6